### PR TITLE
fix: quizframe migration, CloudCSEMovie theme docs, repoConfig update

### DIFF
--- a/content/00ChangeLog/_index.md
+++ b/content/00ChangeLog/_index.md
@@ -35,7 +35,7 @@ weight: 5
   - When this Utility and documentation is polished, it will eliminate the need for docker_build/_run scripts in each repo and the tax of maintaining/updating them.
 - {{% badge style="info" icon="fa-solid fa-circle-plus" title=" " %}}New{{% /badge %}} Created [utility](https://github.com/FortinetCloudCSE/CentralRepo/blob/prreviewJune23/scripts/upgrade_repo.sh) to upgrade older repos to latest feature set including automated conversion of config.toml to repoConfig.json/hugo.toml
 - {{% badge style="note" title=" " color="magenta"%}}Update{{% /badge %}} Update [gitHub action](https://github.com/FortinetCloudCSE/CentralRepo/blob/main/scripts/static.yml) to use latest API versioned commands
-- {{% badge style="info" icon="fa-solid fa-circle-plus" title=" "%}}New{{% /badge %}} Added [Quizdown shortcode](https://github.com/FortinetCloudCSE/CentralRepo/blob/main/layouts/shortcodes/quizdown.html). Check [MD Page]({{% ref "02Hugo/3_create_md" %}}) for usage instructions
+- {{% badge style="info" color="orange" icon="fa-fw fas fa-exclamation-triangle" title=" " %}}Change{{% /badge %}} Replaced Quizdown with [CTF Quiz App quizframe shortcode](https://github.com/FortinetCloudCSE/CentralRepo/blob/main/layouts/shortcodes/quizframe.html). Check [MD Page]({{% ref "02Hugo/3_create_md" %}}) for usage instructions
 ---
 
 ## 2024

--- a/content/01GettingStarted/2_HugoFrontmatter/index.md
+++ b/content/01GettingStarted/2_HugoFrontmatter/index.md
@@ -19,7 +19,7 @@ example of repoConfig.json.  Replace each value with specific parameters for you
 - repoName (your repo name from GitHub)
 - author
 - Workshop Title
-- themeVariant (options: ["Workshop", "Demo", "UseCase", "Spotlight", "Xperts2024, Xperts2025"] )
+- themeVariant (options: ["Workshop", "Demo", "UseCase", "Spotlight", "Xperts2024", "Xperts2025", "CloudCSEMovie"] )
 - logoBannerText (whatever you want in top left Menu under Fortinet Logo.  Leaving this field blank will default to the themeVariant name)
 - logoBannerSub Text (optional sub-banner text)
 - marketingCode (optional marketing code to be used as default in analytics gathering and provisioning form)
@@ -27,6 +27,8 @@ example of repoConfig.json.  Replace each value with specific parameters for you
 - bannerLine2 (optional text for XPerts Content Header banner line 2)
 - bannerLine3 (optional text for XPerts Content Header banner line 3)
 - quizUrl (optional URL for quiz to be used in the quiz shortcode)
+- videoHeaderSrc (optional, **CloudCSEMovie theme only** — URL path to the MP4, e.g. `"/videos/header-bg.mp4"`. Hugo strips the `static/` prefix — do NOT include it in the path. Leave blank to disable.)
+- videoHeaderInterval (optional, **CloudCSEMovie theme only** — total seconds between the start of each video play cycle. Defaults to `60`. Must be greater than the video duration.)
 - Shortcuts (Helpful Resources Links in the left menu
   - Text (Display Text)
   - URL (URL for the resource)
@@ -41,7 +43,7 @@ example of repoConfig.json.  Replace each value with specific parameters for you
   "repoName":"UserRepo",
   "author":"CSE Employee",
   "workshopTitle":"Hugo for Fortinet TECWorkshops",
-  "themeVariant":"Xperts2025",
+  "themeVariant":"CloudCSEMovie",
   "logoBannerText":"",
   "logoBannerSubText":"",
   "errorLevel":"warning",
@@ -51,6 +53,8 @@ example of repoConfig.json.  Replace each value with specific parameters for you
   "bannerLine2":"Workshop Title Here",
   "bannerLine3":"Subtitle,Description, or 3rd line Here",
   "quizUrl": "https://forms.gle/yourformhere",
+  "videoHeaderSrc": "/videos/header-bg.mp4",
+  "videoHeaderInterval": "60",
   "shortcuts": [
   {
     "text": "Fortinet Cloud CSE GitHub Org",
@@ -79,3 +83,44 @@ example of repoConfig.json.  Replace each value with specific parameters for you
   ]
 }
 ```
+
+---
+
+## CloudCSEMovie Theme — Video Header Background
+
+The `CloudCSEMovie` theme variant replaces the static header image with a looping MP4 video in the sidebar header area (the same region used by the Xperts background image).
+
+### How it works
+
+- The video plays automatically on page load (muted, no controls)
+- When the video ends, it pauses and replays after a configurable interval — for example, a 6-second video with a 60-second interval plays once, waits 54 seconds, then plays again
+- All other header content (logo, banner text, search bar) renders on top of the video
+
+### Setup steps
+
+**1. Add your MP4 to the repo**
+
+Place the video file in your repo's `static/videos/` folder:
+
+```
+static/
+  videos/
+    header-bg.mp4
+```
+
+**2. Configure repoConfig.json**
+
+```json
+{
+  "themeVariant": "CloudCSEMovie",
+  "videoHeaderSrc": "/videos/header-bg.mp4",
+  "videoHeaderInterval": 60
+}
+```
+
+- `videoHeaderSrc` — the URL path to your MP4, relative to the site root. Required for the video to appear.
+- `videoHeaderInterval` — total seconds from the start of one play to the start of the next. Optional; defaults to `60`. Set this to a value greater than your video's duration.
+
+{{% badge style="note" title=" " color="magenta"%}}Tip{{% /badge %}} Leave `videoHeaderSrc` as an empty string `""` to use the `CloudCSEMovie` theme without a video (renders a solid color header like other themes).
+
+{{% badge style="info" color="orange" icon="fa-fw fas fa-exclamation-triangle" title=" " %}}Note{{% /badge %}} The MP4 file is committed to your repo inside `static/videos/`. Keep it small — short clips under 5MB are ideal for fast page loads.

--- a/content/02Hugo/3_create_md/index.md
+++ b/content/02Hugo/3_create_md/index.md
@@ -111,5 +111,3 @@ sequenceDiagram
     ```
 
     The `page` param is the path to the quiz in the CTF app configured via `quizUrl` in `repoConfig.json`. The shortcode passes `fortiuser`, `fortiemail`, and `workshopID` cookies automatically so attendees are pre-identified.
-
-{{< quizframe page="/example" height="400" >}}

--- a/content/02Hugo/3_create_md/index.md
+++ b/content/02Hugo/3_create_md/index.md
@@ -104,56 +104,12 @@ sequenceDiagram
     Bob-->>John: Jolly good!
 {{< /mermaid >}}
 
-- Quizes with [QuizDown](https://github.com/bonartm/hugo-quiz)
+- Quizes with the CTF Quiz App (`quizframe` shortcode)
 
     ```markdown
-    {{</* quizdown */>}}
-    
-    ## The sound of dog
-    
-    What do dogs sound like?
-    
-    > Some hint
-    
-        - [ ] yes
-        - [ ] no
-        - [ ] `self.sound = "meow"`
-        - [x] wuff
-    
-    ## Put the [days](https://en.wikipedia.org/wiki/Day) in order!
-    
-    > Monday is the _first_ day of the week.
-    
-        1. Monday
-        2. Tuesday
-        3. Wednesday
-        4. Friday
-        5. Saturday
-        
-        {{</* /quizdown */>}}
+    {{</* quizframe page="/your-quiz-page" height="600" */>}}
     ```
 
-{{< quizdown >}}
+    The `page` param is the path to the quiz in the CTF app configured via `quizUrl` in `repoConfig.json`. The shortcode passes `fortiuser`, `fortiemail`, and `workshopID` cookies automatically so attendees are pre-identified.
 
-## The sound of dog
-
-What do dogs sound like?
-    
-> Some hint
-    
-- [ ] yes
-- [ ] no
-- [ ] `self.sound = "meow"`
-- [x] wuff
-
-## Put the [days](https://en.wikipedia.org/wiki/Day) in order!
-
-> Monday is the _first_ day of the week.
-
-1. Monday
-2. Tuesday
-3. Wednesday
-4. Friday
-5. Saturday
-
-{{< /quizdown >}}
+{{< quizframe page="/example" height="400" >}}

--- a/scripts/repoConfig.json
+++ b/scripts/repoConfig.json
@@ -2,12 +2,14 @@
   "repoName":"UserRepo",
   "author":"Jeff Kopko",
   "workshopTitle":"Hugo for Fortinet TECWorkshops",
-  "themeVariant":"Workshop",
+  "themeVariant":"CloudCSEMovie",
   "logoBannerText":"FortiHugo",
   "logoBannerSubText":"",
   "errorLevel":"warning",
   "googleServicesID":"G-5RZBH288ST",
   "marketingCode": "FortiHugo202",
+  "videoHeaderSrc": "/videos/CloudsAnimated.mp4",
+  "videoHeaderInterval": "60",
   "shortcuts": [
   {
     "text": "Fortinet Cloud CSE GitHub Org",


### PR DESCRIPTION
## Summary

- **Quizdown → quizframe migration**: replaced `{{< quizdown >}}` shortcode usage with `{{< quizframe >}}` (CTF quiz app); updated changelog entry; quizdown is removed from CentralRepo
- **CloudCSEMovie theme documentation**: added `videoHeaderSrc` and `videoHeaderInterval` params to HugoFrontmatter docs page; added CloudCSEMovie to themeVariant options list; fixed example path (`/static/videos/` → `/videos/`)
- **repoConfig.json**: switched UserRepo default theme to CloudCSEMovie; added video param defaults

## Test plan
- [x] Hugo builds cleanly with no errors
- [x] Tested in fortihugorunner with latest `hugotester-local` image
- [x] No console errors related to quizdown or quizframe on the updated docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)