### PR TITLE
Add printable-handout tooling (inert by default) and document it

### DIFF
--- a/.github/workflows/handout-pdf.yml
+++ b/.github/workflows/handout-pdf.yml
@@ -1,0 +1,196 @@
+# Renders the generated per-path handouts to PDF.
+#
+# Deliberately a separate workflow from static.yml: static.yml is in the repo
+# template's FILES_TO_COPY, so anything added there is silently reverted by the
+# next template upgrade. This file is not in that list.
+#
+# It never writes to ./docs — that directory is machine-owned (the template
+# upgrade tool deletes it). The build output goes to $RUNNER_TEMP instead.
+name: Handout PDFs
+
+on:
+  # PR-triggered so a real Hugo build failure is visible before merge, not after --
+  # this workflow already runs a full build (see "Build the site" below) before it
+  # renders PDFs, so this reuses that check rather than adding a second copy of it.
+  pull_request:
+    paths:
+      - "content/**"
+      - "layouts/**"
+      - "scripts/gen_handouts.py"
+      - "scripts/repoConfig.json"
+      - ".github/workflows/handout-pdf.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "content/**"
+      - "layouts/**"
+      - "scripts/gen_handouts.py"
+      - "scripts/repoConfig.json"
+      - ".github/workflows/handout-pdf.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "handout-pdf-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  handouts:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: public.ecr.aws/k4n6m5h8/fortinet-hugo:latest
+      LOCAL_IMAGE: fortinet-hugo:latest
+      # Path prefix the site is built for. Every asset in the rendered HTML is
+      # rooted at /UserRepo/..., so the pages must be served under that prefix or
+      # the print stylesheet and images do not load.
+      SITE_PREFIX: UserRepo
+      SERVE_PORT: "8099"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Cheap up-front check: a repo that has not declared deploymentPaths has no
+      # handouts to render at all. Needed because this same file lands in every new
+      # workshop repo (Phase 4) inert by default -- without this, every one of them
+      # would pay for the image pull, Hugo build and headless-Chrome render on every
+      # PR for zero output.
+      - name: Check for any handouts to render
+        id: guard
+        run: |
+          if [ -z "$(python3 scripts/gen_handouts.py --list-slugs)" ]; then
+            echo "No deploymentPaths declared; nothing to render."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail if the committed handouts are stale
+        if: steps.guard.outputs.run == 'true'
+        run: python3 scripts/gen_handouts.py --check
+
+      # Exponential backoff + jitter; ECR returns "toomanyrequests" under load.
+      - name: Pull image (with retries)
+        if: steps.guard.outputs.run == 'true'
+        env:
+          MAX_ATTEMPTS: "7"
+        shell: bash
+        run: |
+          attempt=1
+          while :; do
+            echo "Pull attempt $attempt/$MAX_ATTEMPTS: $IMAGE"
+            docker pull "$IMAGE" && break
+            status=$?
+            if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::Pull failed after $MAX_ATTEMPTS attempts"
+              exit $status
+            fi
+            sleep_secs=$(( (1 << attempt) + (RANDOM % 4) ))
+            echo "Transient error (likely throttle). Sleeping ${sleep_secs}s..."
+            sleep "$sleep_secs"
+            attempt=$(( attempt + 1 ))
+          done
+          docker tag "$IMAGE" "$LOCAL_IMAGE"
+
+      - name: Build the site
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        run: |
+          CONT_ID=$(docker run -d -v "${{ github.workspace }}:/home/UserRepo" "$LOCAL_IMAGE" build)
+          cleanup() { docker rm -f "$CONT_ID" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+
+          STATUS=$(docker wait "$CONT_ID")
+          docker logs "$CONT_ID" 2>&1 | tee "$RUNNER_TEMP/hugo-build.log"
+
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::Hugo build failed with exit code $STATUS"
+            exit "$STATUS"
+          fi
+
+          # errorLevel is "warning" in scripts/repoConfig.json, so Hugo warnings
+          # never fail the build. Surface them explicitly instead of trusting
+          # the exit code.
+          if grep -qE '^(WARN|ERROR)' "$RUNNER_TEMP/hugo-build.log"; then
+            echo "::warning::Hugo emitted warnings — see the build log above"
+          fi
+
+          mkdir -p "$RUNNER_TEMP/serve"
+          docker cp "$CONT_ID:/home/CentralRepo/public" "$RUNNER_TEMP/serve/$SITE_PREFIX"
+
+      - name: Serve the built site
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP/serve"
+          nohup python3 -m http.server "$SERVE_PORT" --bind 127.0.0.1 \
+            > "$RUNNER_TEMP/http.log" 2>&1 &
+          for _ in $(seq 1 20); do
+            if curl -sf -o /dev/null "http://127.0.0.1:$SERVE_PORT/$SITE_PREFIX/index.html"; then
+              echo "server up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Static file server never came up"
+          cat "$RUNNER_TEMP/http.log"
+          exit 1
+
+      - name: Render each handout to PDF
+        if: steps.guard.outputs.run == 'true'
+        shell: bash
+        run: |
+          CHROME=""
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then CHROME="$candidate"; break; fi
+          done
+          if [ -z "$CHROME" ]; then
+            echo "::error::No Chrome/Chromium binary on the runner"
+            exit 1
+          fi
+          "$CHROME" --version
+
+          mkdir -p "$RUNNER_TEMP/pdf"
+          # Slug list comes from the generator, which derives it from
+          # deploymentPaths in scripts/repoConfig.json. Hardcoding it here meant a
+          # third path would build a site and silently ship two PDFs.
+          for slug in $(python3 scripts/gen_handouts.py --list-slugs); do
+            url="http://127.0.0.1:$SERVE_PORT/$SITE_PREFIX/09reference/handouts/$slug/index.print.html"
+            out="$RUNNER_TEMP/pdf/UserRepo-$slug.pdf"
+
+            # --disable-dev-shm-usage is not optional: with the default 64 MB
+            # /dev/shm the longer handout dies with "Printing failed."
+            "$CHROME" \
+              --headless \
+              --no-sandbox \
+              --disable-gpu \
+              --disable-dev-shm-usage \
+              --no-pdf-header-footer \
+              --virtual-time-budget=60000 \
+              --run-all-compositor-stages-before-draw \
+              --print-to-pdf="$out" \
+              "$url"
+
+            if [ ! -s "$out" ]; then
+              echo "::error::$slug produced no PDF"
+              exit 1
+            fi
+            echo "$slug -> $(stat -c%s "$out") bytes"
+          done
+
+      - name: Upload PDFs
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: handout-pdfs
+          path: ${{ runner.temp }}/pdf/*.pdf
+          if-no-files-found: error
+
+      - name: Upload print HTML
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: handout-print-html
+          path: ${{ runner.temp }}/serve/${{ env.SITE_PREFIX }}/09reference/handouts/
+          if-no-files-found: error

--- a/.github/workflows/path-lint.yml
+++ b/.github/workflows/path-lint.yml
@@ -1,0 +1,94 @@
+# Guards the deployment-path invariant: every path-specific instruction lives
+# inside a pathtabs block, and the generated handouts match their source pages.
+#
+# Separate from static.yml on purpose — that file is in the repo template's
+# FILES_TO_COPY, so anything added there is reverted by the next template upgrade.
+name: Path lint
+
+# GitHub Actions does not expand YAML anchors, so the two path lists are
+# duplicated by necessity — keep them in sync.
+on:
+  pull_request:
+    paths:
+      - "content/**"
+      - "layouts/shortcodes/pathtab*.html"
+      - "scripts/gen_handouts.py"
+      - "scripts/lint_paths.py"
+      # gen_handouts.py derives PATHS from deploymentPaths here, and lint_paths.py
+      # imports PATHS from it -- so editing this file changes what the linter
+      # enforces and must trigger it.
+      - "scripts/repoConfig.json"
+      - ".github/workflows/path-lint.yml"
+  # Direct pushes to main skip the pull_request trigger entirely — d512c5c did
+  # exactly that, hand-edited the handouts, and left handout-k8s stale.
+  push:
+    branches: [main]
+    paths:
+      - "content/**"
+      - "layouts/shortcodes/pathtab*.html"
+      - "scripts/gen_handouts.py"
+      - "scripts/lint_paths.py"
+      # gen_handouts.py derives PATHS from deploymentPaths here, and lint_paths.py
+      # imports PATHS from it -- so editing this file changes what the linter
+      # enforces and must trigger it.
+      - "scripts/repoConfig.json"
+      - ".github/workflows/path-lint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Regenerate handouts
+        run: python3 scripts/gen_handouts.py
+
+      - name: Check for a diff
+        id: diff
+        run: |
+          if [ -n "$(git status --porcelain -- content/09Reference/handouts)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Auto-fix needs a push credential GitHub does not recognize as "the workflow
+      # itself" -- a push made with the default GITHUB_TOKEN does not re-trigger this
+      # or any other workflow (GitHub's own recursion guard), so the PR's checks would
+      # stay pinned to the pre-fix commit. HANDOUT_AUTOFIX_PAT is that credential; see
+      # content/02Hugo/7_printable_handouts/index.md for how a repo provisions it.
+      #
+      # UserRepo does not provision this secret -- it ships this file inert, for repos
+      # that opt into deploymentPaths to copy. The guard below is what makes that safe:
+      # with the secret absent, the regenerated files are reverted so the existing
+      # `lint_paths.py` (which shells out to `gen_handouts.py --check`) fails loud on
+      # the real staleness below, instead of a git-auth error or a false-green pass
+      # against files this step already fixed on disk but never pushed.
+      - name: Auto-fix stale handouts
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          HANDOUT_AUTOFIX_PAT: ${{ secrets.HANDOUT_AUTOFIX_PAT }}
+        run: |
+          if [ -z "$HANDOUT_AUTOFIX_PAT" ]; then
+            echo "HANDOUT_AUTOFIX_PAT is not set on this repo -- leaving the stale" \
+                 "handouts uncommitted so lint_paths.py fails loud below. Run" \
+                 "'python3 scripts/gen_handouts.py' locally and commit the result," \
+                 "or provision the secret to enable auto-fix."
+            git checkout -- content/09Reference/handouts
+            git clean -fd -- content/09Reference/handouts
+            exit 0
+          fi
+          git config user.name "handout-autofix[bot]"
+          git config user.email "handout-autofix[bot]@users.noreply.github.com"
+          git add content/09Reference/handouts
+          git commit -m "chore: regenerate stale handouts"
+          git push "https://x-access-token:${HANDOUT_AUTOFIX_PAT}@github.com/${{ github.repository }}.git" "HEAD:${{ github.head_ref || github.ref_name }}"
+
+      - name: Lint deployment paths
+        run: python3 scripts/lint_paths.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,4 @@ There is no test suite; content is validated by rendering. `npm install && hugo 
 - **Repo-local `layouts/` wins over the container's** via `local_copy.sh`. Never land a copy of a CentralRepo shortcode here: the local one shadows it silently and the two drift.
 - **Built page URLs are flat** — `02hugo/6_deployment_paths.html`, not `.../index.html`. Verification greps that assume a directory index find nothing.
 - **Hugo minifies attributes unquoted** in built output (`class=pathgate data-path=docker`). Grepping for `data-path="docker"` returns zero on markup that is present.
+- **`scripts/{gen_handouts,lint_paths}.py` and `.github/workflows/{path-lint,handout-pdf}.yml` sit inert in this repo** — they're ai-101's printable-handout tooling, copied in so every new workshop gets it for free; nothing runs until `deploymentPaths` is declared. See `content/02Hugo/7_printable_handouts/index.md`.

--- a/content/01GettingStarted/3_FortiHugoRunner/index.md
+++ b/content/01GettingStarted/3_FortiHugoRunner/index.md
@@ -106,7 +106,7 @@ $env:Path
 ```
 
 {{% /tab %}}
-{{% /tabs %}}
+{{< /tabs >}}
 
 {{% /tab %}}
 {{% tab title="MacOS/Linux" %}}

--- a/content/02Hugo/6_deployment_paths/index.md
+++ b/content/02Hugo/6_deployment_paths/index.md
@@ -296,7 +296,7 @@ Every message names the offending file. Fix the file it names.
 - **Put decision-making information outside path blocks.** If the prerequisites for each path live inside that path's `pathtab`, a participant who has not chosen yet can see *neither* — the information they need to choose is hidden behind the choice.
 - **If a page now opens with a `notice`, set `description:` in its front matter.** Otherwise the site builds the page's description, its link previews, and its search snippet out of that notice's text.
 - **A page scoped with `deploymentPath` is still reachable.** Menu and next/previous gating cannot stop a bookmark or a shared link. The banner covers this — but it is another reason to keep an opening `notice` that points at the other path's page.
-- **Don't hardcode your path list anywhere else.** The `deploymentPaths` declaration is the single source. Scripts and workflows that need the list should read it from there, or they will quietly keep working with a stale list after you add a path.
+- **Don't hardcode your path list anywhere else.** The `deploymentPaths` declaration is the single source. Scripts and workflows that need the list should read it from there, or they will quietly keep working with a stale list after you add a path. [Printable handouts](/02Hugo/7_printable_handouts/) is a worked example of exactly this — its generator derives everything from this same declaration.
 - **With a site-wide declaration the switch control is site-wide, not per page.** A participant who picks wrongly on page one can fix it from any page — you do not need to repeat a chooser.
 - **`deploymentPath` (singular) needs the site param.** Scoping a whole page to one path gates the menu, the next/previous walk and search, all of which are site-wide; a page-level `deploymentPaths` declaration deliberately touches none of them.
 
@@ -304,3 +304,4 @@ Every message names the offending file. Fix the file it names.
 
 - Shortcode parameters and site params: [CentralRepo README](https://github.com/FortinetCloudCSE/CentralRepo/blob/main/README.md#shortcodes-and-usage)
 - A live workshop using all three mechanisms: [ai-101](https://fortinetcloudcse.github.io/ai-101/) — see its `01Intro` chapter for the chooser, the comparison written outside the blocks, and two path-scoped prerequisite pages
+- Printing a single path cleanly (the print-CSS gap this vocabulary feeds into): [Task 7 — Printable Handouts](/02Hugo/7_printable_handouts/)

--- a/content/02Hugo/7_printable_handouts/index.md
+++ b/content/02Hugo/7_printable_handouts/index.md
@@ -1,0 +1,57 @@
+---
+title: "Task 7 - Printable Handouts"
+linkTitle: "Printable Handouts"
+chapter: false
+weight: 70
+description: "Generate a single-path, print-safe handout for each deployment path — the print stylesheet only ever shows the active tab, so a tabbed page printed as-is silently drops the other path."
+---
+
+### The problem this solves
+
+[Deployment paths](/02Hugo/6_deployment_paths/) show each participant only their own path in the browser: `pathtabs` renders one tab active, one hidden, and JavaScript swaps them on click. That is exactly what makes it useless on paper.
+
+`theme.css` sets `.tab-content { display: none }` with `.tab-content.active { display: block }`. That is not a print-only rule — the print stylesheet only recolours tabs for the page, it does not un-hide anything. So a two-path page, printed or exported to PDF exactly as it renders, contains **one path's steps and zero indication the other path's steps ever existed.** No error, no missing-content notice — the page just looks complete. A participant who prints the Kubernetes path for offline reference silently gets a document with no `helm` commands, or vice versa.
+
+The fix is not a print stylesheet — the tab that isn't active isn't in the printed DOM at all, so no `@media print` rule can recover it. The fix is a **separate, generated page per path**, flattened ahead of time so nothing needs to be hidden. That is what this tooling does.
+
+{{% notice style="note" title="Opt-in — nothing changes until you ask for it" %}}
+The same rule as [deployment paths](/02Hugo/6_deployment_paths/) itself: a workshop that declares no `deploymentPaths` gets no generated handouts, no extra CI time, and no `content/09Reference/handouts/` directory. All four files below already sit in this repo, inert, as of this change — see [How to opt in](#how-to-opt-in).
+{{% /notice %}}
+
+### The four files
+
+| File | Job |
+|---|---|
+| `scripts/gen_handouts.py` | Walks `content/` in site order and, per deployment path, writes one linear page to `content/09Reference/handouts/` with every `pathtabs`/`pathonly`/`tabs` block flattened to that path's body and the other path's content dropped entirely — not collapsed, dropped, because collapsed is exactly the failure mode above. `--check` exits 1 if regenerating would change anything; `--list-slugs` prints the handout slugs and nothing else. |
+| `scripts/lint_paths.py` | Guards the invariant the generator depends on: every path-specific instruction has to actually live inside a `pathtabs`/`pathonly` block (or a page-level `deploymentPath`) or the generator has no way to flatten it correctly. It imports its marker grammar and path vocabulary from `gen_handouts.py` rather than keeping a second copy. Its final check delegates to `gen_handouts.py --check` — a lint pass and a stale-handout are the same failure, reported together. |
+| `.github/workflows/path-lint.yml` | Runs on every PR touching content: regenerates the handouts, and if that produces a diff, commits and pushes the fix back to the PR branch — see [the CI gate](#the-ci-gate) below — then runs `lint_paths.py`. |
+| `.github/workflows/handout-pdf.yml` | Runs a full Hugo build, serves it, and renders each handout to PDF with headless Chrome. PR-triggered so a real build failure (the actual incident this hardening was built after — a bad `pathtabs` block that passed lint but broke the Hugo build) is visible **before** merge, reusing the build step this workflow already ran, rather than adding a third copy of build-and-fail-on-error. |
+
+### How to opt in
+
+Declare `deploymentPaths` — site-wide in `scripts/repoConfig.json`, or page-scoped in a single page's front matter — exactly as described in [Step 1 of the deployment-paths guide](/02Hugo/6_deployment_paths/#step-1--declare-your-paths). The moment a real path vocabulary exists:
+
+- `gen_handouts.py` starts producing pages under `content/09Reference/handouts/`, one per path.
+- `lint_paths.py` starts enforcing that every path-specific instruction sits inside a path block.
+- Both workflows above stop short-circuiting and start doing real work on every PR.
+
+Nothing else changes. `scripts/lint_paths.py`'s own `PATH_TITLE_RE`, `PATH_TOKENS` and `ALLOWLIST` are empty in this repo's copy — they carried ai-101's docker/kubectl/helm vocabulary, which is that workshop's content, not a generic default — so a repo that writes real path-specific lab content should repopulate them the way ai-101 did (see the comments at the top of `scripts/lint_paths.py` for the reuse recipe).
+
+### The CI gate {#the-ci-gate}
+
+"Stale" means the committed pages under `content/09Reference/handouts/` do not match what `gen_handouts.py` would write today — a source page changed and nobody re-ran the generator. `--check` (used by both `lint_paths.py` and `handout-pdf.yml`) catches this and fails loud, naming every changed and orphaned file.
+
+`path-lint.yml` goes one step further: before linting, it runs `gen_handouts.py` for real (not `--check`), and if that produces a diff, it commits and pushes the fix straight to the PR branch using a repo secret named `HANDOUT_AUTOFIX_PAT` — a fine-grained PAT (`contents: write`, scoped to that one repo), not the workflow's own `GITHUB_TOKEN`. That distinction matters: a push made with `GITHUB_TOKEN` deliberately does not re-trigger other workflow runs, so the PR's checks would stay pinned to the stale commit even after the fix landed. A real PAT push does re-trigger, so the PR goes green against the corrected head instead of a run that fixed the problem but couldn't prove it.
+
+**A repo without its own `HANDOUT_AUTOFIX_PAT` still gets the full safety guarantee — just not the auto-fix.** The push step checks the secret is present and non-empty before attempting anything; if it's missing, it reverts its own regeneration and leaves the stale files in place, and `lint_paths.py` fails with the same clear "handouts are stale, re-run `gen_handouts.py`" message it always has. Nothing pushes with an empty credential, nothing produces an opaque git-auth error — the mechanism degrades from self-healing to fail-loud-and-tell-you-how-to-fix-it, never to silently-wrong. This repo (`UserRepo`) does not provision the secret — there is nothing here to print — so this is the path every clone of this template actually exercises.
+
+To get the auto-fix instead of just the fail-loud check, mint a fine-grained PAT the same way `ai-101` did — `contents: write`, scoped to that one repo only — and store it as a repository secret named `HANDOUT_AUTOFIX_PAT`.
+
+### Live example
+
+[**ai-101**](https://github.com/FortinetCloudCSE/ai-101) is the one workshop currently using this end to end: `deploymentPaths` declared site-wide, real `pathtabs` content throughout, `HANDOUT_AUTOFIX_PAT` provisioned, and its own `PATH_TITLE_RE`/`PATH_TOKENS`/`ALLOWLIST` populated with its docker/kubectl/helm vocabulary. Its [published handouts](https://fortinetcloudcse.github.io/ai-101/09reference/handouts/) are the generator's real output.
+
+### Reference
+
+- Deployment paths (the vocabulary this tooling reads): [Task 6](/02Hugo/6_deployment_paths/)
+- A live workshop using the full mechanism: [ai-101](https://github.com/FortinetCloudCSE/ai-101)

--- a/scripts/gen_handouts.py
+++ b/scripts/gen_handouts.py
@@ -1,0 +1,798 @@
+#!/usr/bin/env python3
+"""Generate one linear, single-path handout page per deployment path.
+
+The lab pages are the single source of truth. This script walks ``content/`` in
+site order and, for each deployment path, emits one page with every ``pathtabs`` and
+``pathonly`` block flattened down to that path's body. The other path is dropped
+entirely -- not collapsed behind a tab -- because only the *active* tab is ever
+rendered, in any medium: ``theme.css:2659-2673`` sets ``#R-body .tab-content
+{ display: none }`` with ``.tab-content.active { display: block }``. So a tabbed page
+silently omits the other path. Not a print-only rule -- ``format-print.css:163-176``
+merely recolours tabs for paper and hides nothing.
+
+For the same reason, the *non*-path tab groups (the command-vs-"Expected Output"
+axis) are flattened as well, into labelled subsections. Leaving them as tabs cost
+12 hidden panels in the Docker handout and 17 in the Kubernetes one.
+
+Usage
+-----
+    python3 scripts/gen_handouts.py               # write the handout pages
+    python3 scripts/gen_handouts.py --check       # exit 1 if regenerating would change anything
+    python3 scripts/gen_handouts.py --list-slugs  # one handout slug per line, no writes
+
+Run from the repo root (or anywhere -- paths are resolved relative to this file).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTENT = REPO_ROOT / "content"
+OUT_DIR = CONTENT / "09Reference" / "handouts"
+REPO_CONFIG = REPO_ROOT / "scripts" / "repoConfig.json"
+
+GENERATOR = "scripts/gen_handouts.py"
+
+
+def load_paths() -> list[dict]:
+    """Read the deployment-path vocabulary from scripts/repoConfig.json.
+
+    That file is authoritative because it is the one Hugo reads at build time: it
+    becomes the ``deploymentPaths`` site param, which is where CentralRepo's
+    ``pathtab``/``pathonly`` shortcodes get the keys they accept. Anything else naming
+    the paths -- this script, scripts/lint_paths.py (which imports from here), the PDF
+    workflow (which asks via ``--list-slugs``) -- is downstream of it, so adding a third
+    path means editing one file rather than four that can silently disagree.
+
+    ``slug`` and ``weight`` stay local. They order and name the generated pages, which
+    is this generator's business and not site vocabulary; the site param carries no such
+    fields. ``title`` is taken verbatim -- the theme derives each reader's stored tab
+    selection from ``anchorize(title)``, so retitling or normalising a path silently
+    resets everyone's choice.
+
+    A missing or empty list is a clean no-op, not fatal: most workshop repos never opt
+    into ``deploymentPaths`` at all, and this script (and ``lint_paths.py``, which
+    imports ``PATHS`` from here) has to sit inert in every one of them. ``main()``
+    checks ``PATHS`` up front and returns before touching the filesystem, so "no
+    vocabulary" and "no handouts to generate" are the same case, not a silent pass over
+    an empty target set.
+    """
+    try:
+        config = json.loads(REPO_CONFIG.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"{REPO_CONFIG}: not found; it declares the deployment paths")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{REPO_CONFIG}: not valid JSON ({exc})")
+
+    entries = config.get("deploymentPaths")
+    if not entries:
+        return []
+
+    paths = []
+    for i, entry in enumerate(entries):
+        key, title = entry.get("key"), entry.get("title")
+        if not key or not title:
+            raise SystemExit(
+                f"{REPO_CONFIG}: deploymentPaths[{i}] needs both 'key' and 'title'"
+            )
+        paths.append(
+            {
+                "key": key,
+                "title": title,
+                "slug": f"handout-{key}",
+                "weight": 20 + 10 * i,
+            }
+        )
+    return paths
+
+
+PATHS = load_paths()
+
+# A source page is included in the handouts when it either contains a pathtabs
+# block or declares a whole-page ``deploymentPath``. That is exactly the set of
+# pages carrying path-specific instructions; pure-theory pages are left out so
+# the handout stays a followable command sheet.
+#
+# Directories never walked (the generated output itself).
+EXCLUDE_DIRS = {OUT_DIR}
+
+# Pages skipped even though they contain a pathtabs block, keyed by path relative
+# to content/. The gate page's pathtabs block *is* the interactive path chooser --
+# on paper the path is already chosen, so it has nothing to say.
+EXCLUDE_PAGES = {Path("01Intro/_index.md")}
+
+# Paragraphs that only make sense on the interactive site: they tell the reader to
+# click the other path's tab, which is impossible on paper. Matched against the
+# whole paragraph (these sentences wrap across lines), outside fenced code.
+STRIP_PARAGRAPH_PATTERNS = [
+    re.compile(r"Click the \*\*(Docker Compose|Kubernetes / Helm)\*\* tab"),
+]
+
+# Individual lines dropped from the handout, outside fenced code. Used for table
+# rows -- a whole table is one "paragraph" to the stripper above, so a row must be
+# removed line-by-line. The reference index links the handouts; inside a handout
+# that row would link to the page you are already reading.
+STRIP_LINE_PATTERNS = [
+    re.compile(r"^\|\s*\[Printable handout\]"),
+]
+
+# --------------------------------------------------------------------------
+# Parsing helpers
+#
+# Every marker pattern in this file is also the linter's: scripts/lint_paths.py
+# imports them rather than keeping a second copy, so a shortcode's spelling is
+# declared exactly once. The two scripts disagreeing is not a hypothetical -- the
+# handout flatteners and the linter's tracker have to agree on what a marker *is*
+# or one of them silently ignores a block the other acts on.
+# --------------------------------------------------------------------------
+
+FRONT_MATTER_DELIM = "---"
+FENCE_RE = re.compile(r"^\s*(```+|~~~+)")
+
+# The delimiter each block shortcode is called with. Not a style choice, and not
+# uniform, so it is declared here once and every message that tells an author what to
+# write is generated from it by ``marker_form`` below.
+#
+# ``{{% %}}`` hands the shortcode's body back to the *page's* markdown pass;
+# ``{{< >}}`` makes the shortcode responsible for rendering its own body. For
+# ``pathonly`` that difference is load-bearing and was measured: rendering the body
+# via ``RenderString`` happens in a separate render context, so headings inside the
+# block never join the page's fragment set. ``content/09Reference/_index.md`` links
+# ``[Compose profiles](#compose-profiles)`` at a heading now inside a ``pathonly``
+# block; with ``{{< >}}`` the build warned ``heading ID "compose-profiles" not found``
+# and the link was dead. ``pathtabs`` is the opposite case -- it renders no body of its
+# own, only the wrapper around ``pathtab`` children.
+BLOCK_DELIMS = {"pathtabs": "<", "pathonly": "%", "tabs": "<"}
+
+# ``re.M`` so the same pattern serves both the line-by-line flatteners and the
+# whole-body scan in ``Page.has_path_blocks``.
+PATHTABS_OPEN_RE = re.compile(r"^\s*\{\{<\s*pathtabs\b.*?>\}\}\s*$", re.M)
+PATHTABS_CLOSE_RE = re.compile(r"^\s*\{\{<\s*/\s*pathtabs\s*>\}\}\s*$")
+PATHTAB_OPEN_RE = re.compile(r"^\s*\{\{%\s*pathtab\s+path=\"([^\"]+)\"\s*%\}\}\s*$")
+PATHTAB_CLOSE_RE = re.compile(r"^\s*\{\{%\s*/\s*pathtab\s*%\}\}\s*$")
+
+# ``pathonly`` -- path-specific prose and whole sections outside a tab group. Percent
+# form, like ``pathtab``, for the fragment-set reason in ``BLOCK_DELIMS``. The angle
+# form is the plausible mistake -- it is what ``pathtabs`` and ``tabs`` use -- so it is
+# a hard error here rather than an unmatched line that would flatten to nothing.
+PATHONLY_OPEN_RE = re.compile(r"^\s*\{\{%\s*pathonly\s+path=\"([^\"]+)\"\s*%\}\}\s*$", re.M)
+PATHONLY_CLOSE_RE = re.compile(r"^\s*\{\{%\s*/\s*pathonly\s*%\}\}\s*$")
+PATHONLY_WRONG_DELIM_RE = re.compile(r"^\s*\{\{<\s*/?\s*pathonly\b", re.M)
+
+HEADING_RE = re.compile(r"^(#{1,5})(\s+)(.*)$")
+
+# Plain (non-path) tab groups -- the command-vs-"Expected Output" axis. ``\b`` and
+# the mandatory whitespace before ``title=`` keep these from matching ``pathtabs``
+# / ``pathtab``, which are flattened separately and first.
+TABS_OPEN_RE = re.compile(r"^\s*\{\{<\s*tabs\b.*?>\}\}\s*$")
+TABS_CLOSE_RE = re.compile(r"^\s*\{\{<\s*/\s*tabs\s*>\}\}\s*$")
+TAB_OPEN_RE = re.compile(r"^\s*\{\{%\s*tab\s+.*?title=\"([^\"]*)\".*?%\}\}\s*$")
+TAB_CLOSE_RE = re.compile(r"^\s*\{\{%\s*/\s*tab\s*%\}\}\s*$")
+
+# Any block marker, anywhere on a line, with its delimiter and name captured. The
+# flatteners above match one marker anchored to a whole line; the linter needs the
+# complementary shape -- every marker on a line, in order -- to track nesting without
+# the state leaks a per-line ``if/elif`` chain produced. Both live here so the two
+# scripts cannot drift on what counts as a marker. ``pathtabs`` precedes ``tabs`` in
+# the alternation so the shorter name never claims the longer one's marker; the inner
+# ``pathtab`` / ``tab`` markers are deliberately not matched, because tracking which
+# *block* the reader is in never requires knowing which tab.
+BLOCK_MARKER_RE = re.compile(
+    r"\{\{(?P<delim>[<%])\s*(?P<close>/\s*)?"
+    r"(?P<name>pathtabs|pathonly|tabs)\b(?P<args>[^}]*?)[%>]\}\}"
+)
+
+SIMPLE_FM_RE = re.compile(r"^(\w+)\s*:\s*(.*)$")
+
+
+def marker_form(name: str) -> str:
+    """How to write ``name``'s markers, e.g. ``{{% pathonly … %}}``.
+
+    Every "you wrote the wrong delimiter" message in either script is built from this,
+    so the correction can never contradict ``BLOCK_DELIMS``. That mattered on the first
+    cut of ``pathonly``: the decision on its delimiter reversed once, and hand-written
+    messages in two files then said opposite things.
+    """
+    return "{{% " + name + " ... %}}" if BLOCK_DELIMS[name] == "%" else "{{< " + name + " ... >}}"
+
+
+def split_front_matter(text: str) -> tuple[dict[str, str], str]:
+    """Return (front matter as a flat str->str dict, body)."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != FRONT_MATTER_DELIM:
+        return {}, text
+    for i in range(1, len(lines)):
+        if lines[i].strip() == FRONT_MATTER_DELIM:
+            fm: dict[str, str] = {}
+            for raw in lines[1:i]:
+                m = SIMPLE_FM_RE.match(raw.strip())
+                if m:
+                    fm[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+            return fm, "\n".join(lines[i + 1 :])
+    return {}, text
+
+
+def iter_lines_with_fence_state(lines: list[str]):
+    """Yield (line, in_fence) so transforms never touch fenced code blocks."""
+    fence: str | None = None
+    for line in lines:
+        m = FENCE_RE.match(line)
+        if fence is None:
+            if m:
+                fence = m.group(1)[0] * 3
+                yield line, True
+                continue
+            yield line, False
+        else:
+            yield line, True
+            if m and line.strip().startswith(fence):
+                fence = None
+
+
+# --------------------------------------------------------------------------
+# Page model
+# --------------------------------------------------------------------------
+
+
+class Page:
+    def __init__(self, md_path: Path):
+        self.md_path = md_path
+        self.rel_md = md_path.relative_to(CONTENT)
+        self.rel_dir = md_path.parent.relative_to(CONTENT)
+        text = md_path.read_text(encoding="utf-8")
+        self.front_matter, self.body = split_front_matter(text)
+        self.title = self.front_matter.get("title", md_path.parent.name)
+        self.deployment_path = self.front_matter.get("deploymentPath") or None
+
+    @property
+    def weight(self) -> int:
+        try:
+            return int(self.front_matter.get("weight", "0"))
+        except ValueError:
+            return 0
+
+    @property
+    def has_path_blocks(self) -> bool:
+        """Does this page carry path-specific content in either block shape?
+
+        ``pathonly`` has to count. A page whose only path-specific content is a
+        ``pathonly`` block has no ``pathtabs`` block and no whole-page
+        ``deploymentPath``, so on the ``pathtabs``-only test it was relevant to neither
+        path and dropped out of *both* handouts -- the content would exist on the site
+        and appear on no printed sheet.
+
+        The malformed ``{{< pathonly >}}`` spelling counts as well, so that the page is
+        pulled in and ``flatten_pathonly`` gets to reject it. Left out, a page whose only
+        path content carried that one-character mistake dropped out of both handouts and
+        nothing said so -- the delimiter error hid behind the inclusion test.
+        """
+        return bool(
+            PATHTABS_OPEN_RE.search(self.body)
+            or PATHONLY_OPEN_RE.search(self.body)
+            or PATHONLY_WRONG_DELIM_RE.search(self.body)
+        )
+
+    def relevant_to(self, path_key: str) -> bool:
+        if self.rel_md in EXCLUDE_PAGES:
+            return False
+        if self.deployment_path and self.deployment_path != path_key:
+            return False
+        return self.has_path_blocks or self.deployment_path is not None
+
+
+def collect_pages() -> list[Page]:
+    pages: list[Page] = []
+    for md in sorted(CONTENT.rglob("*.md")):
+        if md.name not in ("index.md", "_index.md"):
+            continue
+        if any(str(md).startswith(str(d)) for d in EXCLUDE_DIRS):
+            continue
+        pages.append(Page(md))
+    return pages
+
+
+def dir_weight(rel_dir: Path, by_dir: dict[Path, Page]) -> int:
+    page = by_dir.get(rel_dir)
+    return page.weight if page else 0
+
+
+def site_order(pages: list[Page]) -> list[Page]:
+    """Sort pages the way the site presents them: section weight, then page weight.
+
+    The key is one (weight, name) pair per path component. A section's own
+    ``_index.md`` has a shorter key than its children, and Python orders a
+    shorter tuple-prefix first, so a section index sorts ahead of its pages.
+    """
+    by_dir = {p.rel_dir: p for p in pages}
+
+    def key(page: Page):
+        parts = page.rel_dir.parts
+        return [
+            (dir_weight(Path(*parts[: i + 1]), by_dir), parts[i])
+            for i in range(len(parts))
+        ]
+
+    return sorted(pages, key=key)
+
+
+# --------------------------------------------------------------------------
+# Body transform
+# --------------------------------------------------------------------------
+
+
+def flatten_pathtabs(body: str, path_key: str, source: str) -> str:
+    """Replace every pathtabs block with just ``path_key``'s body."""
+    out: list[str] = []
+    # None = outside any pathtabs block. Otherwise a dict of block state.
+    block: dict | None = None
+
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        if in_fence:
+            if block is None:
+                out.append(line)
+            elif block["keep"]:
+                block["buf"].append(line)
+            # else: fenced code inside the other path's tab -- dropped
+            continue
+
+        if block is None:
+            if PATHTABS_OPEN_RE.match(line):
+                block = {"buf": [], "keep": False, "seen": set()}
+                continue
+            out.append(line)
+            continue
+
+        if PATHONLY_OPEN_RE.match(line) or PATHONLY_WRONG_DELIM_RE.match(line):
+            raise SystemExit(
+                f"{source}: pathonly inside a pathtabs block is either redundant (same "
+                "path) or dead content (the other path); move it out, or let the pathtab "
+                "body carry the text"
+            )
+
+        m = PATHTAB_OPEN_RE.match(line)
+        if m:
+            key = m.group(1)
+            if key in block["seen"]:
+                raise SystemExit(f"{source}: pathtabs block defines {key!r} twice")
+            block["seen"].add(key)
+            block["keep"] = key == path_key
+            continue
+        if PATHTAB_CLOSE_RE.match(line):
+            block["keep"] = False
+            continue
+        if PATHTABS_CLOSE_RE.match(line):
+            missing = {p["key"] for p in PATHS} - block["seen"]
+            if missing:
+                raise SystemExit(
+                    f"{source}: pathtabs block is missing path(s) {sorted(missing)}"
+                )
+            body_lines = block["buf"]
+            while body_lines and not body_lines[0].strip():
+                body_lines.pop(0)
+            while body_lines and not body_lines[-1].strip():
+                body_lines.pop()
+            out.extend(body_lines)
+            block = None
+            continue
+        if block["keep"]:
+            block["buf"].append(line)
+
+    if block is not None:
+        raise SystemExit(f"{source}: unclosed pathtabs block")
+    return "\n".join(out)
+
+
+def flatten_pathonly(body: str, path_key: str, source: str) -> str:
+    """Inline every ``pathonly`` block belonging to ``path_key``; delete the others.
+
+    A sibling of ``flatten_pathtabs`` rather than a reuse of it. That function refuses a
+    block that does not name every key in ``PATHS``, which is right for a tab group -- a
+    missing tab is a reader left with no instructions at all -- and wrong here: a
+    ``pathonly`` block names exactly one path by design, and the other path's absence is
+    the whole point of the shortcode.
+
+    Every other failure is fatal rather than a warning, for the same reason the
+    shortcode itself uses ``errorf``: a mis-keyed block is either content shown to the
+    wrong reader or content shown to nobody, and both look like working output.
+    """
+    out: list[str] = []
+    keys = {p["key"] for p in PATHS}
+    # None = outside a block. Otherwise True (this path's block) or False (the other's).
+    keep: bool | None = None
+
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        if in_fence:
+            if keep is not False:
+                out.append(line)
+            continue
+
+        if PATHONLY_WRONG_DELIM_RE.match(line):
+            raise SystemExit(
+                f"{source}: write pathonly as {marker_form('pathonly')}, not the angle "
+                "form -- the angle form makes the shortcode render its own body in a "
+                "separate context, so headings inside the block never join the page's "
+                "fragment set and every in-page link to them is dead"
+            )
+
+        m = PATHONLY_OPEN_RE.match(line)
+        if m:
+            if keep is not None:
+                raise SystemExit(f"{source}: nested pathonly blocks are not supported")
+            key = m.group(1)
+            if key not in keys:
+                raise SystemExit(
+                    f"{source}: pathonly has unknown path {key!r}; expected one of "
+                    f"{sorted(keys)}"
+                )
+            keep = key == path_key
+            continue
+        if PATHONLY_CLOSE_RE.match(line):
+            if keep is None:
+                raise SystemExit(f"{source}: pathonly close marker with no open")
+            keep = None
+            continue
+
+        if keep is not False:
+            out.append(line)
+
+    if keep is not None:
+        raise SystemExit(f"{source}: unclosed pathonly block")
+    return "\n".join(out)
+
+
+def flatten_plain_tabs(body: str, source: str) -> str:
+    """Turn every non-path tab group into labelled subsections.
+
+    Path tabs are resolved by ``flatten_pathtabs``; what is left is the
+    command-vs-"Expected Output" axis. Those must be flattened too, for the same
+    reason the path tabs are: ``theme.css:2659-2673`` renders only the *active* tab
+    in every medium, so in a PDF every second and third panel silently disappears. That loses all
+    the expected-output panels a reader needs to check their work on paper, and at
+    least one real instruction ("Follow the logs").
+
+    Each tab becomes a bold label followed by its body. Deliberately not a
+    heading: heading depth here is already four to five levels deep after
+    ``demote_headings``, and these labels do not belong in the table of contents.
+    """
+    out: list[str] = []
+    # None = outside any tab group. Otherwise a list of rendered lines.
+    block: list[str] | None = None
+
+    def emit_label(title: str) -> None:
+        if block and block[-1].strip():
+            block.append("")
+        if title:
+            block.append(f"**{title}**")
+            block.append("")
+
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        if in_fence:
+            (out if block is None else block).append(line)
+            continue
+
+        if block is None:
+            if TABS_OPEN_RE.match(line):
+                block = []
+                continue
+            out.append(line)
+            continue
+
+        if TABS_OPEN_RE.match(line):
+            raise SystemExit(f"{source}: nested tabs groups are not supported")
+        m = TAB_OPEN_RE.match(line)
+        if m:
+            emit_label(m.group(1).strip())
+            continue
+        if TAB_CLOSE_RE.match(line):
+            continue
+        if TABS_CLOSE_RE.match(line):
+            while block and not block[0].strip():
+                block.pop(0)
+            while block and not block[-1].strip():
+                block.pop()
+            out.extend(block)
+            block = None
+            continue
+        block.append(line)
+
+    if block is not None:
+        raise SystemExit(f"{source}: unclosed tabs group")
+    return "\n".join(out)
+
+
+def demote_headings(body: str) -> str:
+    """Push every heading down one level so page titles can be the ``##`` spine."""
+    out: list[str] = []
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        if in_fence:
+            out.append(line)
+            continue
+        m = HEADING_RE.match(line)
+        out.append(f"#{m.group(1)}{m.group(2)}{m.group(3)}" if m else line)
+    return "\n".join(out)
+
+
+def strip_site_only_paragraphs(body: str) -> str:
+    out: list[str] = []
+    para: list[str] = []
+    para_fenced = False
+
+    def flush() -> None:
+        nonlocal para, para_fenced
+        if para and not para_fenced:
+            joined = " ".join(l.strip() for l in para)
+            if any(p.search(joined) for p in STRIP_PARAGRAPH_PATTERNS):
+                para, para_fenced = [], False
+                return
+        out.extend(para)
+        para, para_fenced = [], False
+
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        if in_fence:
+            para_fenced = True
+            para.append(line)
+            continue
+        if not line.strip():
+            flush()
+            out.append(line)
+            continue
+        if any(p.search(line) for p in STRIP_LINE_PATTERNS):
+            continue
+        para.append(line)
+    flush()
+    return "\n".join(out)
+
+
+LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\(\s*([^)\s]+)([^)]*)\)")
+
+
+def _absolute_page_ref(source_dir: Path, dest: str) -> str:
+    """``../../09Reference/`` on a page in 05Security/1_lab -> ``/09Reference``.
+
+    Hugo's link render hook resolves a ``/``-rooted content path to a real page and
+    emits the baseURL-prefixed URL, so the link survives being moved into the
+    handout bundle. Verified against this image: relative sibling refs warn
+    ``is not a page or a resource``, ``/``-rooted refs do not.
+    """
+    anchor = ""
+    if "#" in dest:
+        dest, anchor = dest.split("#", 1)
+        anchor = "#" + anchor
+    if not dest:
+        return anchor
+    target = (source_dir / dest).as_posix()
+    parts: list[str] = []
+    for part in target.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    if parts and parts[-1] in ("index.md", "_index.md"):
+        parts.pop()
+    return "/" + "/".join(parts) + anchor
+
+
+def rewrite_refs(body: str, page: Page, resources: dict[str, Path]) -> str:
+    """Make links and images valid from the handout bundle's location.
+
+    Page links become ``/``-rooted content refs. Bundle-resource images are
+    recorded in ``resources`` for copying into the handout bundle under a
+    collision-proof name, and rewritten to that bare name so they stay genuine
+    page resources (no ``is not a resource`` warning, works in print and PDF).
+    """
+    prefix = page.rel_dir.as_posix().replace("/", "-").lower()
+
+    def repl(m: re.Match) -> str:
+        bang, text, dest, tail = m.groups()
+        if dest.startswith(("http://", "https://", "mailto:", "#", "/")):
+            return m.group(0)
+        if bang:
+            src = (page.md_path.parent / dest.lstrip("./")).resolve()
+            if not src.is_file():
+                return m.group(0)
+            name = f"{prefix}-{src.name}"
+            resources[name] = src
+            return f"{bang}[{text}]({name}{tail})"
+        return f"{bang}[{text}]({_absolute_page_ref(page.rel_dir, dest)}{tail})"
+
+    out: list[str] = []
+    for line, in_fence in iter_lines_with_fence_state(body.splitlines()):
+        out.append(line if in_fence else LINK_RE.sub(repl, line))
+    return "\n".join(out)
+
+
+def collapse_blank_runs(body: str) -> str:
+    out: list[str] = []
+    blanks = 0
+    for line in body.splitlines():
+        if line.strip():
+            blanks = 0
+            out.append(line)
+        else:
+            blanks += 1
+            if blanks < 3:
+                out.append("")
+    return "\n".join(out).strip("\n")
+
+
+def render_page(page: Page, path_key: str, resources: dict[str, Path]) -> str:
+    source = str(page.md_path.relative_to(REPO_ROOT))
+    # Order matters twice over. ``flatten_pathtabs`` runs first because it is the only
+    # pass that can still see -- and reject -- a ``pathonly`` block nested inside a
+    # ``pathtab`` body; once the other passes have run, that nesting is indistinguishable
+    # from a top-level block. ``flatten_pathonly`` then runs before
+    # ``flatten_plain_tabs`` so a ``pathonly`` block wrapping a command/output tab group
+    # is dropped whole, instead of the tab flattener first turning it into labelled
+    # subsections that the next pass has to delete again.
+    body = flatten_pathtabs(page.body, path_key, source)
+    body = flatten_pathonly(body, path_key, source)
+    body = flatten_plain_tabs(body, source)
+    body = strip_site_only_paragraphs(body)
+    body = rewrite_refs(body, page, resources)
+    body = demote_headings(body)
+    return collapse_blank_runs(body)
+
+
+# --------------------------------------------------------------------------
+# Output
+# --------------------------------------------------------------------------
+
+
+def build_handout(spec: dict, pages: list[Page], resources: dict[str, Path]) -> str:
+    included = [p for p in pages if p.relevant_to(spec["key"])]
+    parts = [
+        "---",
+        f'title: "Handout — {spec["title"]}"',
+        f'linkTitle: "Handout — {spec["title"]}"',
+        f'weight: {spec["weight"]}',
+        "hidden: true",
+        f'deploymentPath: {spec["key"]}',
+        'outputs: ["html", "print"]',
+        "---",
+        "",
+        f'{{{{% notice style="note" title="Generated file — do not edit" %}}}}',
+        f"This page is generated by `{GENERATOR}` from the workshop pages. Edit the",
+        f"source pages instead and re-run the generator; CI fails if this file is stale.",
+        "",
+        f"It contains **only the {spec['title']} path**. Print it, or use your browser's",
+        "print view for a clean single-path PDF.",
+        "{{% /notice %}}",
+        "",
+    ]
+    for page in included:
+        rendered = render_page(page, spec["key"], resources)
+        if not rendered.strip():
+            continue
+        parts.append(f"## {page.title}")
+        parts.append("")
+        parts.append(rendered)
+        parts.append("")
+        parts.append("---")
+        parts.append("")
+    while parts and parts[-1] in ("", "---"):
+        parts.pop()
+    return "\n".join(parts).rstrip("\n") + "\n"
+
+
+def build_section_index() -> str:
+    rows = "\n".join(
+        f'| [Handout — {s["title"]}]({s["slug"]}/) | `{s["key"]}` |' for s in PATHS
+    )
+    return f"""---
+title: "Printable handouts"
+linkTitle: "Printable handouts"
+weight: 20
+hidden: true
+---
+
+One linear page per deployment path, containing only that path's steps. Generated
+from the workshop pages by `{GENERATOR}` — do not edit the handouts by hand.
+
+| Handout | Path |
+|---|---|
+{rows}
+
+Each handout also renders a print-optimised variant at `index.print.html`, which is
+what CI turns into a PDF artifact.
+"""
+
+
+def targets() -> dict[Path, bytes]:
+    """Every byte OUT_DIR should contain. OUT_DIR is fully generator-owned."""
+    pages = site_order(collect_pages())
+    out: dict[Path, bytes] = {
+        OUT_DIR / "_index.md": build_section_index().encode("utf-8")
+    }
+    for spec in PATHS:
+        resources: dict[str, Path] = {}
+        bundle = OUT_DIR / spec["slug"]
+        out[bundle / "index.md"] = build_handout(spec, pages, resources).encode("utf-8")
+        for name, src in resources.items():
+            out[bundle / name] = src.read_bytes()
+    return out
+
+
+def existing() -> set[Path]:
+    if not OUT_DIR.exists():
+        return set()
+    return {p for p in OUT_DIR.rglob("*") if p.is_file()}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if regenerating would change anything (CI freshness gate)",
+    )
+    ap.add_argument(
+        "--list-slugs",
+        action="store_true",
+        help="print one handout slug per line and exit (for the PDF workflow's loop)",
+    )
+    args = ap.parse_args()
+
+    # No vocabulary -- clean no-op. Checked before --list-slugs so a repo that has
+    # never opted in gets the same "nothing to do" outcome from every mode; checked
+    # before touching the filesystem so --check and the plain write mode never create
+    # or delete a single file. The log line goes to stderr, not stdout, so
+    # --list-slugs still prints nothing on stdout -- handout-pdf.yml's early-exit
+    # guard greps stdout for exactly that.
+    if not PATHS:
+        if not args.list_slugs:
+            print(
+                f"{REPO_CONFIG}: no deploymentPaths declared; nothing to do.",
+                file=sys.stderr,
+            )
+        return 0
+
+    # Answered before anything is read or written, so the PDF workflow can ask which
+    # handouts exist without depending on the content tree being buildable.
+    if args.list_slugs:
+        for path in PATHS:
+            print(path["slug"])
+        return 0
+
+    wanted = targets()
+    orphans = sorted(existing() - set(wanted))
+
+    if args.check:
+        stale = [
+            path
+            for path, content in wanted.items()
+            if not path.exists() or path.read_bytes() != content
+        ]
+        if stale or orphans:
+            print("Handouts are stale. Re-run:  python3 " + GENERATOR, file=sys.stderr)
+            for path in stale:
+                print(f"  changed: {path.relative_to(REPO_ROOT)}", file=sys.stderr)
+            for path in orphans:
+                print(f"  orphan:  {path.relative_to(REPO_ROOT)}", file=sys.stderr)
+            return 1
+        print(f"Handouts up to date ({len(wanted)} files).")
+        return 0
+
+    for path, content in sorted(wanted.items()):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        print(f"wrote {path.relative_to(REPO_ROOT)}")
+    for path in orphans:
+        path.unlink()
+        print(f"removed {path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_paths.py
+++ b/scripts/lint_paths.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Fail the build when deployment-path content drifts out of its path block.
+
+The workshop supports two deployment paths. A reader picks one on the gate page
+and every later page must follow that choice, which only works if *every*
+path-specific instruction lives inside a ``pathtabs`` block (or on a page whose
+front matter declares a single ``deploymentPath``). A ``kubectl`` command sitting
+in unbranched prose is invisible to that mechanism: the Docker reader sees it and
+has no way to know it does not apply to them.
+
+This linter is the guardrail for that invariant. It checks:
+
+1. path-like titles in a plain ``tabs`` group -- a hand-rolled path switch that
+   does not synchronise with the reader's choice
+2. hand-written ``groupid="deploy-path"`` -- bypasses the pathtabs shortcode and
+   its missing-path check
+3. path-specific tokens outside a path block -- with an explicit allowlist below.
+   Fenced code is checked too: a bare ``kubectl`` fence outside a path block is the
+   most likely place for this leak to appear, not the least
+4. ``cd "~`` anywhere -- bash does not expand ``~`` inside double quotes, so the
+   command always fails
+5. block markup that either tool would silently mis-parse: a block written with the
+   other delimiter form, an unknown ``path=`` key, a path block nested in another, a
+   marker sharing a line with anything else, and any block still open at end of file
+6. stale generated handouts (delegates to ``gen_handouts.py --check``)
+
+Usage
+-----
+    python3 scripts/lint_paths.py            # lint, exit 1 on any violation
+    python3 scripts/lint_paths.py --list     # print the config and exit
+
+Reusing this in another workshop repo: take ``gen_handouts.py`` with it -- this file
+imports the path vocabulary and the marker grammar from it -- then keep the CONFIG
+block's structure and empty out ``PATH_TITLE_RE``, ``PATH_TOKENS`` and ``ALLOWLIST``.
+Checks 1 and 3 then no-op and the repo still gets checks 2, 4 and 5.
+
+This is that reused copy, in ``UserRepo``: ``PATH_TITLE_RE``, ``PATH_TOKENS`` and
+``ALLOWLIST`` below are emptied per the instructions above, since ai-101's docker/k8s
+vocabulary would otherwise false-positive on this repo's own prose about the
+deployment-path feature (which names Docker and Kubernetes constantly as its worked
+example). ``gen_handouts.py``'s ``deploymentPaths`` no-op handles the separate case of
+a repo, like this one by default, that has not opted into the feature at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The marker grammar and the path vocabulary are the handout generator's, imported
+# rather than restated. Two copies of "what a marker looks like" is this linter's own
+# failure mode one level up: when the two scripts disagree, the linter passes a page the
+# generator cannot parse, or reports a block the generator ignores. A plain sibling
+# import works because this script is always run as a script, so ``sys.path[0]`` is
+# ``scripts/`` -- the two files travel together as a pair.
+#
+# This also makes the linter depend on scripts/repoConfig.json, which is where the
+# generator reads the paths from. Deliberate: a linter enforcing a vocabulary the site
+# is not built with would be worse than one that refuses to start.
+from gen_handouts import (
+    BLOCK_DELIMS,
+    BLOCK_MARKER_RE,
+    FENCE_RE,
+    FRONT_MATTER_DELIM,
+    PATHS,
+    marker_form,
+)
+
+# ==========================================================================
+# CONFIG -- the path vocabulary. Everything repo-specific lives in this block.
+# ==========================================================================
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTENT = REPO_ROOT / "content"
+
+# Generated single-path pages. Path tokens outside pathtabs are the whole point
+# there, so the token checks would be nothing but false positives. Their
+# freshness is checked separately (check 6).
+GENERATED_DIRS = [CONTENT / "09Reference" / "handouts"]
+
+# Front-matter key that marks a whole page as belonging to one path.
+PAGE_PATH_KEY = "deploymentPath"
+
+# Keys accepted by the pathtab/pathonly shortcodes, which now live in CentralRepo and
+# read `deploymentPaths` from scripts/repoConfig.json. Derived, not restated: PATHS is
+# itself built from that file, so this linter enforces the same vocabulary Hugo builds
+# with. Adding a path is a one-file edit.
+PATH_KEYS = [p["key"] for p in PATHS]
+
+# A tab title matching this is a path switch. Catching it in a plain `tabs` group
+# is the point: such a group has its own random groupid, so clicking it does not
+# follow the reader's choice on any other page.
+#
+# Empty in this copy -- ai-101's vocabulary (docker/kubernetes/helm) is that
+# workshop's content, not this repo's. See the reuse note in the module docstring.
+# A pattern that can never match, rather than an empty alternation (which errors).
+PATH_TITLE_RE = re.compile(r"(?!)")
+
+# Tokens that only make sense on one path. Each is (label, regex).
+#
+# Commands are the obvious half and were the whole list to begin with. Both leaks
+# that actually shipped were the other half -- prose naming one path's runtime as
+# *the* way the lab is wired: "the agent container reaches the MCP server container
+# at ... using the Docker service hostname" (content/04MCP/_index.md) and "Docker
+# Engine + Compose v2" (content/_index.md). To a Kubernetes reader, who has no Docker
+# daemon at all, that reads as authoritative rather than as one of two options, which
+# is the same harm as an unbranched `docker compose` command.
+# Tokens that only make sense on one path, keyed (label, regex) -- ai-101's list.
+# Empty in this copy: this repo has no lab content to leak a runtime detail from, and
+# the tokens below (docker/kubectl/helm/...) are exactly the words this repo's own
+# documentation about the deployment-path feature uses as its worked example. See the
+# reuse note in the module docstring. A repo that copies this file and does write
+# path-specific lab content should repopulate this list the way ai-101 did.
+PATH_TOKENS: list[tuple[str, re.Pattern]] = []
+
+# Lines allowed to carry a path token outside a path block. Each entry needs a
+# reason -- if you cannot write one, the line probably belongs in a pathtabs block.
+#
+# ``file`` is relative to content/ (or None for any file); ``match`` must appear
+# in the line.
+#
+# Empty in this copy -- these entries were ai-101's gate page (01Intro/_index.md),
+# which does not exist here. See the reuse note in the module docstring.
+ALLOWLIST: list[dict] = []
+
+# ==========================================================================
+# Implementation
+# ==========================================================================
+
+# Backticked prose is not markup. A sentence mentioning `{{< pathtabs >}}` inline used
+# to flip the tracker on and suppress every path-token check to the end of the file,
+# and skipping fenced code never helped -- inline code is not a fence.
+INLINE_CODE_RE = re.compile(r"`+[^`]*`+")
+
+# Blocks whose body is scoped to one path, so path tokens inside them are already
+# branched. They may not nest: see the nested-path-block violation below.
+PATH_BLOCKS = ("pathtabs", "pathonly")
+
+# ``pathonly`` takes exactly one attribute. Anything else is either a typo or an
+# attempt to grow the signature, which the handout generator's anchored marker
+# regexes would stop matching -- silently, producing a handout with the shortcode
+# still in it.
+PATHONLY_ARGS_RE = re.compile(r'^\s*path="([^"]+)"\s*$')
+
+TAB_TITLE_RE = re.compile(r"\{\{%\s*tab\s+[^%]*title=\"([^\"]+)\"")
+GROUPID_RE = re.compile(r"groupid\s*=\s*\"deploy-path\"")
+BAD_TILDE_RE = re.compile(r'cd\s+"~')
+
+
+class Violation:
+    def __init__(self, path: Path, line_no: int, check: str, detail: str, line: str):
+        self.path = path
+        self.line_no = line_no
+        self.check = check
+        self.detail = detail
+        self.line = line.strip()
+
+    def __str__(self) -> str:
+        rel = self.path.relative_to(REPO_ROOT)
+        return f"{rel}:{self.line_no}: [{self.check}] {self.detail}\n    {self.line}"
+
+
+def front_matter_value(lines: list[str], key: str) -> str | None:
+    if not lines or lines[0].strip() != FRONT_MATTER_DELIM:
+        return None
+    for raw in lines[1:]:
+        if raw.strip() == FRONT_MATTER_DELIM:
+            return None
+        m = re.match(rf"^{key}\s*:\s*(.*)$", raw.strip())
+        if m:
+            return m.group(1).strip().strip('"').strip("'")
+    return None
+
+
+def allowed(rel_md: Path, line: str) -> bool:
+    for entry in ALLOWLIST:
+        if entry["file"] is not None and Path(entry["file"]) != rel_md:
+            continue
+        if entry["match"] in line:
+            return True
+    return False
+
+
+def content_pages() -> list[Path]:
+    pages = []
+    for md in sorted(CONTENT.rglob("*.md")):
+        if md.name not in ("index.md", "_index.md"):
+            continue
+        if any(gen in md.parents for gen in GENERATED_DIRS):
+            continue
+        pages.append(md)
+    return pages
+
+
+def lint_page(md: Path) -> list[Violation]:
+    lines = md.read_text(encoding="utf-8").splitlines()
+    rel_md = md.relative_to(CONTENT)
+    page_path = front_matter_value(lines, PAGE_PATH_KEY)
+    violations: list[Violation] = []
+
+    # A page declaring a single deploymentPath is itself a path block, so tokens
+    # anywhere on it are already scoped. Its marker must still be a real path.
+    if page_path and page_path not in PATH_KEYS:
+        violations.append(
+            Violation(md, 1, "page-marker", f"unknown {PAGE_PATH_KEY}: {page_path!r}", page_path)
+        )
+    page_is_path_scoped = page_path in PATH_KEYS
+
+    fence: str | None = None
+    # Depths, not booleans. As booleans the first close ended a nested group, and the
+    # outer block's remaining lines were then treated as unbranched prose.
+    depth = {"pathtabs": 0, "pathonly": 0, "tabs": 0}
+
+    for i, line in enumerate(lines, start=1):
+        m = FENCE_RE.match(line)
+        if fence is not None:
+            if m and line.strip().startswith(fence):
+                fence = None
+            in_fence = True
+        elif m:
+            fence = m.group(1)[0] * 3
+            in_fence = True
+        else:
+            in_fence = False
+
+        if BAD_TILDE_RE.search(line):
+            violations.append(
+                Violation(
+                    md,
+                    i,
+                    "tilde-in-quotes",
+                    'bash does not expand ~ inside double quotes; use cd ~/... or "$AI101_HOME/..."',
+                    line,
+                )
+            )
+
+        # Every check that reads *markup* skips fenced code, and each for its own
+        # reason: a fenced ``{{< pathtabs >}}`` documents the shortcode rather than
+        # using it, and flipping a tracker on it would suppress the token check for the
+        # rest of the page; a fenced groupid="deploy-path" is likewise an example of
+        # what not to write. The token check below deliberately does *not* skip fences.
+        opened_here: set[str] = set()
+        if not in_fence:
+            if GROUPID_RE.search(line):
+                violations.append(
+                    Violation(
+                        md,
+                        i,
+                        "handwritten-groupid",
+                        'use the pathtabs shortcode instead of groupid="deploy-path"',
+                        line,
+                    )
+                )
+
+            markup = INLINE_CODE_RE.sub(" ", line)
+            markers = list(BLOCK_MARKER_RE.finditer(markup))
+            for marker in markers:
+                name = marker.group("name")
+                if marker.group("delim") != BLOCK_DELIMS[name]:
+                    violations.append(
+                        Violation(
+                            md,
+                            i,
+                            "wrong-delimiter",
+                            f"write {name} as {marker_form(name)} -- the delimiter is part "
+                            "of the shortcode's contract, and the wrong one fails silently: "
+                            "the block renders, but ungated, and any heading inside it drops "
+                            "out of the page's fragment set so in-page links to it go dead",
+                            line,
+                        )
+                    )
+                if marker.group("close") is not None:
+                    depth[name] = max(0, depth[name] - 1)
+                    continue
+                if name in PATH_BLOCKS and (depth["pathtabs"] or depth["pathonly"]):
+                    violations.append(
+                        Violation(
+                            md,
+                            i,
+                            "nested-path-block",
+                            f"a {name} block inside another path block is either redundant (same "
+                            "path) or dead content (the other path); move it out, or let the "
+                            "enclosing block's body carry the text",
+                            line,
+                        )
+                    )
+                if name == "pathonly":
+                    args = PATHONLY_ARGS_RE.match(marker.group("args"))
+                    if not args:
+                        violations.append(
+                            Violation(
+                                md,
+                                i,
+                                "pathonly-args",
+                                'pathonly takes exactly one attribute: path="KEY", where KEY is '
+                                f"one of {', '.join(PATH_KEYS)}",
+                                line,
+                            )
+                        )
+                    elif PATH_KEYS and args.group(1) not in PATH_KEYS:
+                        # No site-level PATH_KEYS means no site vocabulary to check
+                        # against -- a page can declare its own deploymentPaths in
+                        # front matter instead (see content/02Hugo/6_deployment_paths),
+                        # and this linter has no way to see that page-scoped list, so
+                        # it stays silent rather than rejecting a key it cannot know.
+                        violations.append(
+                            Violation(
+                                md,
+                                i,
+                                "unknown-path",
+                                f"unknown path {args.group(1)!r}; use one of "
+                                f"{', '.join(PATH_KEYS)}",
+                                line,
+                            )
+                        )
+                depth[name] += 1
+                opened_here.add(name)
+
+            if markers and (len(markers) > 1 or BLOCK_MARKER_RE.sub("", markup).strip()):
+                violations.append(
+                    Violation(
+                        md,
+                        i,
+                        "marker-not-alone",
+                        "put each block marker alone on its own line -- gen_handouts.py matches "
+                        "them anchored to the whole line, so a shared line is never flattened and "
+                        "ships into the handout as a raw shortcode",
+                        line,
+                    )
+                )
+
+            # ``opened_here`` covers a group opened and closed on one line, whose depth
+            # is already back to zero by the time the title is inspected.
+            if depth["tabs"] or "tabs" in opened_here:
+                title = TAB_TITLE_RE.search(line)
+                if title and PATH_TITLE_RE.search(title.group(1)):
+                    violations.append(
+                        Violation(
+                            md,
+                            i,
+                            "path-tab-outside-pathtabs",
+                            f"tab title {title.group(1)!r} looks like a deployment path; "
+                            "use pathtabs so it follows the reader's choice",
+                            line,
+                        )
+                    )
+
+        in_path_block = bool(
+            depth["pathtabs"] or depth["pathonly"] or opened_here.intersection(PATH_BLOCKS)
+        )
+        if in_path_block or page_is_path_scoped:
+            continue
+        if allowed(rel_md, line):
+            continue
+        for label, token in PATH_TOKENS:
+            if token.search(line):
+                violations.append(
+                    Violation(
+                        md,
+                        i,
+                        "token-outside-path-block",
+                        f"{label!r} is path-specific; wrap it in pathtabs, set "
+                        f"{PAGE_PATH_KEY} on the page, or add an allowlist entry with a reason",
+                        line,
+                    )
+                )
+                break
+
+    # An unbalanced block is what makes a tracker leak, and a leaked tracker is silent
+    # -- it suppresses checks rather than reporting anything. Hugo also rejects an
+    # unclosed shortcode, but only once the block is genuinely unclosed; this fires as
+    # well when the tracker itself has desynchronised, which is the case worth hearing
+    # about.
+    for name, open_blocks in depth.items():
+        if open_blocks:
+            violations.append(
+                Violation(
+                    md,
+                    len(lines),
+                    f"unclosed-{name}",
+                    f"{open_blocks} {name} block(s) still open at end of file; give every "
+                    f"{marker_form(name)} a matching close marker",
+                    "",
+                )
+            )
+
+    return violations
+
+
+def check_handouts() -> list[str]:
+    # Still a subprocess rather than a call into the imported module: --check has to
+    # compare what a *fresh* run writes against what is on disk, and the generator's
+    # exit status and stderr are the contract this reports.
+    gen = REPO_ROOT / "scripts" / "gen_handouts.py"
+    proc = subprocess.run(
+        [sys.executable, str(gen), "--check"], capture_output=True, text=True
+    )
+    if proc.returncode == 0:
+        return []
+    return [line for line in (proc.stdout + proc.stderr).splitlines() if line.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--list", action="store_true", help="print the config and exit")
+    args = ap.parse_args()
+
+    if args.list:
+        print(f"path keys:   {', '.join(PATH_KEYS) or '(none)'}")
+        print(f"page marker: {PAGE_PATH_KEY}")
+        print(f"markers:     {', '.join(marker_form(n) for n in BLOCK_DELIMS)}")
+        print("tokens:")
+        for label, token in PATH_TOKENS:
+            print(f"  {label:26} {token.pattern}")
+        print(f"allowlist:   {len(ALLOWLIST)} entries")
+        for entry in ALLOWLIST:
+            print(f"  {entry['file'] or '<any>':28} {entry['match'][:40]!r} -- {entry['why']}")
+        return 0
+
+    violations: list[Violation] = []
+    pages = content_pages()
+    for md in pages:
+        violations.extend(lint_page(md))
+
+    stale = check_handouts()
+
+    for v in violations:
+        print(str(v), file=sys.stderr)
+    if stale:
+        print("[stale-handouts] generated handouts do not match the source pages:", file=sys.stderr)
+        for line in stale:
+            print(f"    {line}", file=sys.stderr)
+
+    if violations or stale:
+        print(
+            f"\nlint_paths: {len(violations)} violation(s) in {len(pages)} page(s)"
+            + (", handouts stale" if stale else ""),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"lint_paths: clean ({len(pages)} pages, handouts up to date)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phases 4–5 of `ai-101/plans/0004_2026-08-20_Jeff-Kopko_handout-ci-and-branch-protection-hardening.md`, implemented independently in UserRepo (a sibling session is doing Phase 1/3 in ai-101 itself).

- Copies `scripts/gen_handouts.py`, `scripts/lint_paths.py`, `.github/workflows/path-lint.yml` and `.github/workflows/handout-pdf.yml` from ai-101, with fixes applied to the copies:
  - **P3.1/P3.2**: missing/empty `deploymentPaths` is now a clean no-op (log to stderr, exit 0, no files touched) in both scripts instead of a fatal `SystemExit` — required for the tooling to sit inert in a repo that hasn't opted in.
  - **P1.2**: `path-lint.yml`'s `lint` job regenerates handouts and, on a diff, commits + pushes the fix to the PR's head ref using a `HANDOUT_AUTOFIX_PAT` secret (not `GITHUB_TOKEN`, which wouldn't retrigger CI). UserRepo doesn't provision that secret, so the push step reverts its own regeneration and lets `lint_paths.py` fail loud with the existing "stale, re-run gen_handouts.py" message — no opaque git-auth error, no false-green.
  - **P1.3**: `handout-pdf.yml` now also runs on `pull_request`, closing the gap where a real Hugo build failure only surfaced post-merge.
  - **P1.4**: a cheap `--list-slugs` guard skips the image pull / build / PDF-render steps when no `deploymentPaths` are declared.
- **P4.3**: verified UserRepo builds/lints/handout-checks cleanly as-is (no `deploymentPaths`) — both new workflows short-circuit for the right reason.
- **P4.4**: verified the opt-in path against a throwaway `deploymentPaths` + `pathtabs` page (reverted before this commit) — generation, staleness detection, and both auto-fix guard branches all behaved as designed.
- Fixed one unrelated pre-existing bug the new linter caught: a nested `tabs` group in `3_FortiHugoRunner/index.md` was closed with the wrong delimiter.
- Adds `content/02Hugo/7_printable_handouts/index.md` (Task 7) documenting the mechanism, cross-linked from `6_deployment_paths/index.md`, plus a `CLAUDE.md` gotcha pointer.

Branch protection (Phase 2) is out of scope — handled separately via API.

## Test plan

- [x] `python3 scripts/gen_handouts.py --check` — passes (no-op) against current `repoConfig.json`
- [x] `python3 scripts/lint_paths.py` — clean, 30 pages
- [x] Full local Hugo build via `docker run ... fortinet-hugo:latest build` — exit 0, no new warnings/errors
- [x] Throwaway `deploymentPaths` + `pathtabs` test page: confirmed staleness detection, generation, `--list-slugs`, and both auto-fix guard branches (secret present vs. absent) behave correctly; reverted before commit
- [ ] CI on this PR (`path-lint`, `handout-pdf`, Lacework, codex review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)